### PR TITLE
Add Content-Security-Policy and Referrer-Policy to Enhance Visitor's Security and Privacy

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,6 +1,7 @@
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta http-equiv="Content-Security-Policy" content="Content-Security-Policy: default-src 'none'; script-src 'self' 'sha256-5kMb497w7ItxXRHeDONhgk1HOjOqzAVeP4/0KPiMW0Y=' 'sha256-tTF1yX+RjpAH9BXtHp0JAHdFvbp+J0ug0F5JFBf4nyM=' https://use.typekit.net https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; img-src 'self' https://p.typekit.net https://www.google-analytics.com https://hackadaycom.files.wordpress.com; font-src 'self' https://use.typekit.net data://*; connect-src https://use.typekit.net https://p.typekit.net; frame-ancestors 'none'; form-action 'none'; base-uri hardenedlinux.github.io; upgrade-insecure-requests; block-all-mixed-content;">
   
   <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,6 +2,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta http-equiv="Content-Security-Policy" content="Content-Security-Policy: default-src 'none'; script-src 'self' 'sha256-5kMb497w7ItxXRHeDONhgk1HOjOqzAVeP4/0KPiMW0Y=' 'sha256-tTF1yX+RjpAH9BXtHp0JAHdFvbp+J0ug0F5JFBf4nyM=' https://use.typekit.net https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; img-src 'self' https://p.typekit.net https://www.google-analytics.com https://hackadaycom.files.wordpress.com; font-src 'self' https://use.typekit.net data://*; connect-src https://use.typekit.net https://p.typekit.net; frame-ancestors 'none'; form-action 'none'; base-uri hardenedlinux.github.io; upgrade-insecure-requests; block-all-mixed-content;">
+  <meta http-equiv="Referrer-Policy" content="no-referrer, no-referrer-when-downgrade, strict-origin-when-cross-origin">
   
   <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
 


### PR DESCRIPTION
As a security website, we have to set some basic protections for our own website. This pull request adds `Content-Security-Policy` and `Referrer-Policy`.

`Content-Security-Policy` restricts the resources that are allowed to load by the browser. I set a restrictive policy for our website. If someone posted a article with external images, or any audio files or videos, it will be blocked by the browser. Forms are disallowed. If we need them, we can simply change the policy in the future, it is much more easier than tweaking grsecurity policies anyway... See the full explanation of the policy below.

`Referrer-Policy` stops external websites from tracking our users, the policy is, `no-referrer, no-referrer-when-downgrade, strict-origin-when-cross-origin`, which means, if user's browser only supports `no-referrer`, then don't sent referrers to other websites. If user is using a new browser, don't send referrers to a HTTP website, and also just send the domain name, hardenedlinux.org, not the specific article that allows precise tracking.

Explanation of Content-Security-Policy:

```
# block all resources by default
default-src 'none';

script-src 'self' 
           # two inline scripts on the homepage, for Google and Typekit,
	   # should be moved to seperate files for JavaScript
           'sha256-5kMb497w7ItxXRHeDONhgk1HOjOqzAVeP4/0KPiMW0Y='
           'sha256-tTF1yX+RjpAH9BXtHp0JAHdFvbp+J0ug0F5JFBf4nyM='
           https://use.typekit.net
           https://www.google-analytics.com;

style-src  'self'
           # this sucks, but required by Typekit
           # we shoud get rid of webfonts or self-host one...
           'unsafe-inline';

img-src    'self'
           https://p.typekit.net
           https://www.google-analytics.com
           # this sucks, we should self-host these images
           https://hackadaycom.files.wordpress.com;

font-src   'self'
           https://use.typekit.net
           # this sucks, but required by Typekit, really need
           # to self-host the webfonts.
           data://*;

connect-src https://use.typekit.net
            https://p.typekit.net;

# No iframe
frame-ancestors 'none';

# No form
form-action 'none';

base-uri hardenedlinux.github.io

# Upgrade all HTTP to HTTPS
upgrade-insecure-requests;

# No mixed content in HTTPS
block-all-mixed-content;
```